### PR TITLE
Update Version so it's not a pre-release package

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -12,7 +12,7 @@ jobs:
     
     strategy:
       matrix:
-        dotnet-version: ['3.1', '6.x']
+        dotnet-version: ['6.x']
         
     name: .NET v${{ matrix.dotnet-version }}
 
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: |
-            3.1
             6.x
       
       - name: Install dependencies for .NET ${{ matrix.dotnet-version }}
@@ -36,5 +35,3 @@ jobs:
         
       - name: Test
         run: dotnet test
-        
-      

--- a/Intacct.SDK.Tests/Intacct.SDK.Tests.csproj
+++ b/Intacct.SDK.Tests/Intacct.SDK.Tests.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.29" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" Condition="'$(TargetFramework)' == 'net6'"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5"><IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-<PrivateAssets>all</PrivateAssets>
-</PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <None Include="Credentials/Ini/*.ini">

--- a/Intacct.SDK/Intacct.SDK.csproj
+++ b/Intacct.SDK/Intacct.SDK.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>3.2.3</VersionPrefix>
-    <VersionSuffix>lockstep</VersionSuffix>
+    <VersionPrefix>13.2.3</VersionPrefix>
     <PackageVersion Condition="'$(VersionSuffix)' == ''">$(VersionPrefix)</PackageVersion>
     <PackageVersion Condition="'$(VersionSuffix)' != ''">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
     <PackageId>Intacct.SDK</PackageId>
@@ -15,6 +14,9 @@
     <PackageReleaseNotes>https://github.com/Intacct/intacct-sdk-net/releases</PackageReleaseNotes>
     <Copyright>Copyright © 2022 Sage Intacct, Inc.</Copyright>
     <PackageTags>intacct sdk sage</PackageTags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)\artifacts</PackageOutputPath>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
@@ -22,14 +24,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.29" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.29" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.29" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.29" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="3.1.29" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="3.1.29" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.29" Condition="'$(TargetFramework)' == 'netcoreapp3.1'"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" Condition="'$(TargetFramework)' == 'net6'"/>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6'"/>
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6'"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" Condition="'$(TargetFramework)' == 'net6'"/>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="NLog" Version="5.0.4" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />

--- a/intacct-sdk-net.sln
+++ b/intacct-sdk-net.sln
@@ -7,6 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Intacct.SDK", "Intacct.SDK\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Intacct.SDK.Tests", "Intacct.SDK.Tests\Intacct.SDK.Tests.csproj", "{E3636424-5894-4B8C-8511-1BD5CDCF1074}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_Config", "_Config", "{198E7A3F-98E2-4862-B954-5412C008C3DE}"
+	ProjectSection(SolutionItems) = preProject
+		.github\workflows\dotnet-ci.yml = .github\workflows\dotnet-ci.yml
+		.github\workflows\publish.yml = .github\workflows\publish.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
- Version number no longer contains 'lockstep', but will instead start at 13.2.3 (the official one is at 3.2.2)
- Set a static output directory for NuGet packages
- Include XML documentation with the NuGet package
- Remove .NET Core 3.1, it's EOL